### PR TITLE
Updated Absence Request Approval

### DIFF
--- a/src/app/dashboard/forms/absence-request/page.tsx
+++ b/src/app/dashboard/forms/absence-request/page.tsx
@@ -13,7 +13,6 @@ import { AbsenceRequest } from '@/lib/types';
 import { AbsenceTable } from '@/components/forms/absence-request/employee-absence-table';
 
 import { EarlyOutForm } from '@/components/forms/absence-request/volunteer-early-out';
-import { TruckElectric } from 'lucide-react';
 
 export default function Page() {
   const [employeeFirestoreID, setEmployeeFirestoreID] = useState("");
@@ -232,11 +231,11 @@ export default function Page() {
           <h2 className="text-2xl font-bold text-center mb-6">Employee Login</h2>
           <div className="mb-4">
             <label htmlFor="employeeId" className="block text-gray-700">Employee ID</label>
-            <input type="text" id="employeeId" value={employeeID} onChange={(e) => setEmployeeID(e.target.value)} className="w-full p-2 border rounded" required autoComplete="off"/>
+            <input type="password" id="employeeId" value={employeeID} onChange={(e) => setEmployeeID(e.target.value)} className="w-full p-2 border rounded" required autoComplete="off"/>
           </div>
           <div className="mb-6">
             <label htmlFor="birthYear" className="block text-gray-700">Birth Year</label>
-            <input type="text" id="birthYear" value={year} onChange={(e) => setYear(e.target.value)} className="w-full p-2 border rounded" required autoComplete="off"/>
+            <input type="password" id="birthYear" value={year} onChange={(e) => setYear(e.target.value)} className="w-full p-2 border rounded" required autoComplete="off"/>
           </div>
           <button type="submit" className="w-full bg-blue-500 text-white p-2 rounded cursor-pointer hover:bg-indigo-500 hover:border-indigo-400">Login</button>
           {error && <p className="text-red-500 text-center mt-4">{error}</p>}

--- a/src/app/dashboard/hr-table/page.tsx
+++ b/src/app/dashboard/hr-table/page.tsx
@@ -40,7 +40,7 @@ export default function Page() {
   const [absences, setAbsences] = useState<AbsenceRequest[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [officeFilter, setOfficeFilter] = useState('all');
-  const [activeFilter, setActiveFilter] = useState('active');
+  const [activeFilter, setActiveFilter] = useState('active_and_pending');
   const [pendingNotesOnly, setPendingNotesOnly] = useState(false);
 
   const [currentPage, setCurrentPage] = useState(1);
@@ -312,7 +312,8 @@ export default function Page() {
               <th onClick={() => handleSort('statusBadge')} className="px-6 py-4 text-left text-xs font-bold text-gray-500 uppercase tracking-wider whitespace-nowrap cursor-pointer">Status<SortIcon columnKey="statusBadge" currentSortKey={sortConfig.key} direction={sortConfig.direction}/></th>
               <th onClick={() => handleSort('pendingDOAPoints')} className="text-left text-xs font-bold text-gray-500 uppercase tracking-wider whitespace-normal max-w-[80px] w-20 leading-tight select-none cursor-pointer">Pending DOA<SortIcon columnKey="pendingDOAPoints" currentSortKey={sortConfig.key} direction={sortConfig.direction}/></th>
               <th onClick={() => handleSort('DOAPoints')} className="text-left text-xs font-bold text-gray-500 uppercase tracking-wider whitespace-normal max-w-[60px] w-20 leading-tight select-none cursor-pointer">Final DOA<SortIcon columnKey="DOAPoints" currentSortKey={sortConfig.key} direction={sortConfig.direction}/></th>
-              <th className="px-6 py-4 text-right text-xs font-bold text-gray-500 uppercase tracking-wider">Edit</th>
+              <th onClick={() => handleSort('DAP')} className="text-right pr-2 text-xs font-bold text-gray-500 uppercase tracking-wider whitespace-normal max-w-[60px] w-20 leading-tight select-none cursor-pointer">DAP<SortIcon columnKey="DAP" currentSortKey={sortConfig.key} direction={sortConfig.direction}/></th>
+              {/*<th className="px-6 py-4 text-right text-xs font-bold text-gray-500 uppercase tracking-wider">Edit</th>*/}
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-50">
@@ -350,10 +351,11 @@ export default function Page() {
                 <td className="whitespace-nowrap">
                   <div className="px-1 text-sm font-bold text-slate-900">{a.DOAPoints ? a.DOAPoints : '0'}</div>
                 </td>
-                <td className="px-3 py-4 text-right">
-                  <button onClick={() => setSelectedAbsence(a)} className="p-2 text-black hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-all">
+                <td className="pr-4 text-right whitespace-nowrap">
+                  <div className="px-1 text-sm font-bold text-slate-900">{a.DAP ? a.DAP : '0'}</div>
+                  {/*<button onClick={() => setSelectedAbsence(a)} className="p-2 text-black hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-all">
                     <Edit3 className="h-5 w-5"/>
-                  </button>
+                  </button>*/}
                 </td>
               </tr>
               ))) : (

--- a/src/app/dashboard/tools/approval/page.tsx
+++ b/src/app/dashboard/tools/approval/page.tsx
@@ -36,6 +36,7 @@ export default function Page() {
 
   const [selectedRequest, setSelectedRequest] = useState<AbsenceRequest | null>(null);
   const [managerNotes, setManagerNotes] = useState('');
+  const [finalNotes, setFinalNotes] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Derived values from context to keep code readable
@@ -70,6 +71,15 @@ export default function Page() {
       console.log("All Requests:", allRequests);
     }
   }, [user, userOffices, userRole, userName, authLoading, startDate, endDate]);
+
+  const finalizedAllRequests = useMemo(() => {
+    return allRequests.filter(r => {
+      if (userRole === 'Manager') {
+        return r.manager_approval !== 'not_required';
+      }
+      return allRequests;
+    });
+  }, [allRequests, userRole]);
 
   const pendingEmployeeActionAbsences = useMemo (() => {
     return pendingEmployeeAbsences;
@@ -126,11 +136,13 @@ export default function Page() {
   const handleOpenModal = (request: AbsenceRequest) => {
     setSelectedRequest(request);
     setManagerNotes(request.manager_notes || '');
+    setFinalNotes(request.final_notes || '');
   };
 
   const handleCloseModal = () => {
     setSelectedRequest(null);
     setManagerNotes('');
+    setFinalNotes('');
   };
 
   const handleApproval = async (decision: 'approved' | 'denied' | 'approved_with_note') => {
@@ -152,6 +164,7 @@ export default function Page() {
             final_approval: decision,
             final_approval_name: userName, // Fixed the typo from your snippet
             manager_notes: managerNotes,
+            final_notes: finalNotes
           };
       }
 
@@ -233,7 +246,7 @@ export default function Page() {
             onClick={() => setActiveTab('all')}
             className={`${activeTab === 'all' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors flex-shrink-0`}
           >
-            All Active Requests ({allRequests.length})
+            All Active Requests ({finalizedAllRequests.length})
           </button>
 
           <button
@@ -266,14 +279,12 @@ export default function Page() {
             Denied ({deniedRequests.length})
           </button>
 
-          {(userRole === 'Director' || userRole === 'HR') && (
           <button
             onClick={() => setActiveTab('pending_employee')}
             className={`${activeTab === 'pending_employee' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors flex-shrink-0`}
           >
             Pending Employee Action ({pendingEmployeeActionAbsences.length})
           </button>
-          )}
           
           {/* Invisible spacer to ensure padding on the far right when scrolled to the end */}
           <div className="flex-shrink-0 w-4 md:hidden" aria-hidden="true" />
@@ -282,7 +293,7 @@ export default function Page() {
            
       <div className="mt-4">
         {activeTab === 'all' && (
-          <RequestTable requests={allRequests} userRole={userRole} onViewDetails={handleOpenModal} />
+          <RequestTable requests={finalizedAllRequests} userRole={userRole} onViewDetails={handleOpenModal} />
         )}
         {activeTab === 'pending' && (
           <RequestTable requests={pendingRequests} userRole={userRole} onViewDetails={handleOpenModal} />
@@ -306,8 +317,10 @@ export default function Page() {
           selectedRequest={selectedRequest}
           userRole={userRole}
           managerNotes={managerNotes}
+          finalNotes={finalNotes}
           isSubmitting={isSubmitting}
           setManagerNotes={setManagerNotes}
+          setFinalNotes={setFinalNotes}
           handleCloseModal={handleCloseModal}
           handleApproval={handleApproval}
         />

--- a/src/components/approval/approval.ts
+++ b/src/components/approval/approval.ts
@@ -85,6 +85,7 @@ export async function getAbsenceRequestsByUser(user: User, startDateString: stri
 
 // Helper to derive the visible text status from an object
 export const getRequestStatusText = (req: AbsenceRequest): string => {
+  if (req.status === 'pending_action') return "Pending Employee";
   if (req.manager_approval === 'denied' && req.final_approval === 'pending') return "Manager Denied";
   if (req.manager_approval === 'denied' || req.final_approval === 'denied') return "Denied";
   if (req.final_approval === 'approved') return "Approved";

--- a/src/components/approval/hr-request-details-modal.tsx
+++ b/src/components/approval/hr-request-details-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo } from 'react';
-import { X, Clock, MessageSquare, Save, Archive, ArchiveRestore, AlertCircle, FileText, User, Plus, Paperclip } from 'lucide-react';
+import { X, Clock, MessageSquare, Save, Archive, ArchiveRestore, AlertCircle, FileText, User, Plus, Paperclip, FileEdit } from 'lucide-react';
 import { AbsenceRequest } from "@/lib/types";
 import { ref, uploadBytes, getDownloadURL, deleteObject} from "firebase/storage";
 import { storage } from '@/lib/firebase.config';
@@ -18,6 +18,7 @@ interface HRDetailsProps {
 
 export const HRRequestDetailsModal = ({ absence, userName, onClose, onUpdate, onArchive, isSaving }: HRDetailsProps) => {
   const [tempData, setTempData] = React.useState<AbsenceRequest>(absence);
+  const [isNotesForcedOpen, setIsNotesForcedOpen] = React.useState<boolean>(false);
 
   const [deleteFiles, setDeleteFiles] = React.useState<string[]>([]);
   const [newFiles, setNewFiles] = React.useState<File[]>([]); // Track files not yet uploaded
@@ -54,6 +55,8 @@ export const HRRequestDetailsModal = ({ absence, userName, onClose, onUpdate, on
   const canEditETD = tempData.type_of_incident === 'Early Out' || tempData.type_of_incident === 'Leave and Come Back';
   const canEditETA = tempData.type_of_incident === 'Late In' || tempData.type_of_incident === 'Leave and Come Back';
 
+  // Condition to show final notes text area (Automatically shows if it has text, or if button was clicked)
+  const showFinalNotes = !!tempData.final_notes || isNotesForcedOpen;
 
   return (
     <div className="fixed inset-0 bg-slate-900/60 backdrop-blur-md z-50 flex items-center justify-center p-4" onClick={onClose}>
@@ -228,6 +231,9 @@ export const HRRequestDetailsModal = ({ absence, userName, onClose, onUpdate, on
                 <option value="HR Call In">HR Call In</option>
                 <option value="Incident Notice">Incident Notice</option>
                 <option value="Time Off Request">Time Off Request</option>
+                <option value="No Call">No Call</option>
+                <option value="Call In After Shift">Call In After Shift</option>
+                <option value="Previously Not Approved">Previous Not Approved</option>
               </select>
             </div>
           </div>
@@ -323,7 +329,6 @@ export const HRRequestDetailsModal = ({ absence, userName, onClose, onUpdate, on
               {['pending', 'submitted', 'not_provided'].map((status) => {
                 const isSelected = tempData.excuse_note_submitted === status;
                 const fieldChanged = isChanged('excuse_note_submitted');
-
                 // Logic: Disable "Not Provided" if any files exist (staged or database)
                 const hasFiles = (tempData.excuse_note?.length || 0) > 0 || newFiles.length > 0;
                 const notProvidedDisabled = status === 'not_provided' && hasFiles;
@@ -429,7 +434,19 @@ export const HRRequestDetailsModal = ({ absence, userName, onClose, onUpdate, on
             {/* Final Approval Box */}
             <div className={`space-y-3 p-3 col-span-2 md:col-span-1 rounded-2xl border transition-all shadow-sm ${isChanged('final_approval') ? 'bg-rose-50 border-rose-200' : 'bg-sky-200/50 border-sky-200'}`}>
               <div className="flex justify-between items-center ml-1">
-                <label className="text-[10px] font-black text-black uppercase ml-1">Final Approval</label>
+                <div className="flex items-center gap-2">
+                  <label className="text-[10px] font-black text-black uppercase ml-1">Final Approval</label>
+                  {/* 💡 📝 Dynamic Notes Trigger Button inside Box */}
+                  {!showFinalNotes && (
+                    <button 
+                      type="button" 
+                      onClick={() => setIsNotesForcedOpen(true)}
+                      className="text-[9px] font-black text-indigo-600 bg-white hover:bg-indigo-50 border border-indigo-200 px-2 py-0.5 rounded-full uppercase flex items-center gap-1 transition-all"
+                    >
+                      <FileEdit className="h-2.5 w-2.5" /> Add Notes
+                    </button>
+                  )}
+                </div>
                 {tempData.final_approval_name && (
                   <span className={`text-[9px] font-bold italic transition-colors ${isChanged('final_approval') ? 'text-rose-600' : 'text-emerald-800'}`}>
                     Submitted {tempData.final_approval_name}
@@ -462,17 +479,30 @@ export const HRRequestDetailsModal = ({ absence, userName, onClose, onUpdate, on
               </div>
             </div>
           </div>
-          {/* Section 6: Manager Exemption and DOA Points*/}
-          <div className = "grid grid-cols-1 md:grid-cols-3 gap-6 border-slate-100">
-            {/* Manager Exemption Box */}
-            <div className={`p-4 rounded-2xl col-span-2 md:col-span-1 border transition-all flex items-center justify-between shadow-sm ${ isChanged('skipManagerApproval') ? 'bg-rose-50 border-rose-200' : 'bg-slate-200/50 border-slate-200' }`}>
-              <div className="flex items-center gap-3">
-                <div className={`p-2 rounded-lg ${tempData.skipManagerApproval ? 'bg-emerald-100 text-emerald-600' : 'bg-blue-200 text-slate-500'}`}><User className="h-4 w-4" /></div>
-                <div><p className="text-[11px] font-black text-black uppercase leading-none">Manager Exemption</p><p className="text-[9px] font-bold text-slate-400 uppercase tracking-tighter italic">Skip Manager Approval</p></div>
-              </div>
-              <button type="button" onClick={() => setTempData({ ...tempData, skipManagerApproval: !tempData.skipManagerApproval, manager_approval: !tempData.skipManagerApproval ? 'not_required' : 'pending'})} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${tempData.skipManagerApproval ? 'bg-emerald-500' : 'bg-slate-700'}`}><span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${tempData.skipManagerApproval ? 'translate-x-6' : 'translate-x-1'}`} /></button>
-            </div>
 
+          {/* Final Notes for Employee to see, needs to press button to see this part of the form */}
+          {showFinalNotes && (
+            <div className={`space-y-1 p-3 rounded-2xl border transition-all shadow-sm animate-in fade-in slide-in-from-top-2 duration-200 ${ isChanged('final_notes') ? 'bg-rose-50 border-rose-200' : 'bg-sky-200/50 border-sky-200' }`}>
+              <label className="text-[10px] font-black text-black uppercase ml-1 flex items-center gap-1 ">Final Notes</label>
+              <textarea 
+                className="w-full bg-transparent border-none text-sm font-bold focus:ring-0 resize-none overflow-hidden text-slate-800" 
+                placeholder="(Final Notes for Employee Viewing)" 
+                value={tempData.final_notes || ''} 
+                onChange={e => {
+                    setTempData({...tempData, final_notes: e.target.value});
+                    e.target.style.height = 'auto';
+                    e.target.style.height = e.target.scrollHeight + 'px';
+                }}
+                onFocus={(e) => {
+                    e.target.style.height = 'auto';
+                    e.target.style.height = e.target.scrollHeight + 'px';
+                }}
+              />
+            </div>
+          )}
+
+          {/* Section 6: Manager Exemption and DOA Points*/}
+          <div className = "grid grid-cols-2 gap-6 border-slate-100">
             {/* Pending DOA Points Box */}
             <div className={`p-4 rounded-2xl col-span-2 md:col-span-1 border transition-all flex items-center justify-between shadow-sm ${ isChanged('pendingDOAPoints') ? 'bg-rose-50 border-rose-200' : 'bg-sky-200/50 border-sky-200' }`}>
               <div className="flex items-center gap-3">
@@ -519,8 +549,40 @@ export const HRRequestDetailsModal = ({ absence, userName, onClose, onUpdate, on
               />
             </div>
 
+            {/* Manager Exemption Box */}
+            <div className={`p-4 rounded-2xl col-span-2 md:col-span-1 border transition-all flex items-center justify-between shadow-sm ${ isChanged('skipManagerApproval') ? 'bg-rose-50 border-rose-200' : 'bg-slate-200/50 border-slate-200' }`}>
+              <div className="flex items-center gap-3">
+                <div className={`p-2 rounded-lg ${tempData.skipManagerApproval ? 'bg-emerald-100 text-emerald-600' : 'bg-blue-200 text-slate-500'}`}><User className="h-4 w-4" /></div>
+                <div><p className="text-[11px] font-black text-black uppercase leading-none">Manager Exemption</p><p className="text-[9px] font-bold text-slate-400 uppercase tracking-tighter italic">Skip Manager Approval</p></div>
+              </div>
+              <button type="button" onClick={() => setTempData({ ...tempData, skipManagerApproval: !tempData.skipManagerApproval, manager_approval: !tempData.skipManagerApproval ? 'not_required' : 'pending'})} className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${tempData.skipManagerApproval ? 'bg-emerald-500' : 'bg-slate-700'}`}><span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${tempData.skipManagerApproval ? 'translate-x-6' : 'translate-x-1'}`} /></button>
+            </div>
+
+            {/* DAP Points Box */}
+            <div className={`p-4 rounded-2xl col-span-2 md:col-span-1 border transition-all flex items-center justify-between shadow-sm ${ isChanged('DAP') ? 'bg-rose-50 border-rose-200' : 'bg-sky-200/50 border-sky-200' }`}>
+              <div className="flex items-center gap-3">
+                <div className={`p-2 rounded-lg ${tempData.DAP > 0 ? 'bg-amber-100 text-amber-600' : 'bg-blue-200 text-slate-500'}`}>
+                  <AlertCircle className="h-4 w-4" />
+                </div>
+                <div>
+                  <p className="text-[11px] font-black text-black uppercase leading-none">Pending DAP</p>
+                  <p className="text-[9px] font-bold text-slate-400 uppercase tracking-tighter italic">DAP Points</p>
+                </div>
+              </div>
+  
+              <input 
+                type="number" 
+                min="0" 
+                step="any"
+                value={tempData.DAP || ''} 
+                onChange={e => setTempData({...tempData, DAP: parseFloat(e.target.value) || 0})}
+                className="w-20 h-10 text-center font-bold text-lg bg-white rounded-xl border-none shadow-inner focus:ring-2 focus:ring-blue-400"
+                placeholder="0"
+              />
+            </div>
+
             {/* Notes Box */}
-            <div className={`col-span-3 space-y-1 p-3 rounded-2xl border transition-all shadow-sm ${ isChanged('manager_notes') ? 'bg-rose-50 border-rose-200' : 'bg-sky-200/50 border-sky-200' }`}>
+            <div className={`col-span-2 space-y-1 p-3 rounded-2xl border transition-all shadow-sm ${ isChanged('manager_notes') ? 'bg-rose-50 border-rose-200' : 'bg-sky-200/50 border-sky-200' }`}>
               <label className="text-[10px] font-black text-black uppercase ml-1 flex items-center gap-1">Admin Notes</label>
               <textarea 
                 className="w-full bg-transparent border-none text-sm font-bold focus:ring-0 resize-none overflow-hidden" 

--- a/src/components/approval/request-details-modal.tsx
+++ b/src/components/approval/request-details-modal.tsx
@@ -6,8 +6,10 @@ interface RequestDetailsModalProps {
   selectedRequest: AbsenceRequest;
   userRole: string;
   managerNotes: string;
+  finalNotes: string;
   isSubmitting: boolean;
   setManagerNotes: (notes: string) => void;
+  setFinalNotes: (notes: string) => void;
   handleCloseModal: () => void;
   handleApproval: (status: 'approved' | 'denied' | 'approved_with_note') => void;
 }
@@ -16,8 +18,10 @@ const RequestDetailsModal: React.FC<RequestDetailsModalProps> = ({
   selectedRequest,
   userRole,
   managerNotes,
+  finalNotes,
   isSubmitting,
   setManagerNotes,
+  setFinalNotes,
   handleCloseModal,
   handleApproval,
 }) => {
@@ -160,14 +164,22 @@ const RequestDetailsModal: React.FC<RequestDetailsModalProps> = ({
                 {selectedRequest.employee_comments || "No comments provided."}
               </p>
             </div>
-              {!(selectedRequest.type_of_request === "HR Call In" && userRole === 'Manager') && !((selectedRequest.final_approval === 'approved' || selectedRequest.final_approval === 'denied') && userRole === 'Manager') && (
-                <div>
-                  <h4 className="text-xs font-bold text-gray-400 uppercase mb-2">Admin Notes</h4>
-                  <p className="text-sm text-gray-700 bg-white p-3 border rounded-md italic">
-                    {selectedRequest.manager_notes || "No notes provided."}
-                  </p>
-                </div>
-              )}
+            {!(selectedRequest.type_of_request === "HR Call In" && userRole === 'Manager') && !((selectedRequest.final_approval === 'approved' || selectedRequest.final_approval === 'denied') && userRole === 'Manager') && (
+              <div>
+                <h4 className="text-xs font-bold text-gray-400 uppercase mb-2">Admin Notes</h4>
+                <p className="text-sm text-gray-700 bg-white p-3 border rounded-md italic">
+                  {selectedRequest.manager_notes || "No notes provided."}
+                </p>
+              </div>
+            )}
+            {selectedRequest.final_notes && (
+              <div className="col-span-2">
+                <h4 className="text-xs font-bold text-gray-400 uppercase mb-2">Final Notes (Employee Viewable)</h4>
+                <p className="text-sm text-gray-700 bg-white p-3 border rounded-md italic">
+                  {selectedRequest.final_notes || "No notes provided."}
+                </p>
+              </div>
+            )}
           </section>
 
           {/* Section: Approval Workflow */}
@@ -204,24 +216,31 @@ const RequestDetailsModal: React.FC<RequestDetailsModalProps> = ({
 
           {/* Decision Area */}
           {canTakeAction && !(selectedRequest.type_of_request === "HR Call In" && userRole === 'Manager') && !((selectedRequest.final_approval === 'approved' || selectedRequest.final_approval === 'denied') && userRole === 'Manager') && (
-            <section className="bg-indigo-50 p-4 rounded-xl border border-indigo-100">
-              <h3 className="text-sm font-bold text-indigo-900 mb-3 uppercase tracking-tighter">Admin Notes</h3>
-              <textarea
-                rows={3}
-                className="block w-full text-sm p-3 rounded-lg border border-indigo-200 focus:ring-2 focus:ring-indigo-500 outline-none"
-                placeholder="Add Notes (Optional)..."
-                value={managerNotes}
-                onChange={(e) => setManagerNotes(e.target.value)}
-              />
-            </section>
-          )}
-          {/*!canTakeAction && !(userRole === 'Manager') && (
-
-            <div className="text-center text-sm italic text-gray-500">
-              {managerNotes}
+            <div>
+              <section className="bg-indigo-50 p-4 mb-4 rounded-xl border border-indigo-100">
+                <h3 className="text-sm font-bold text-indigo-900 mb-3 uppercase tracking-tighter">Admin Notes</h3>
+                <textarea
+                  rows={3}
+                  className="block w-full text-sm p-3 rounded-lg border border-indigo-200 focus:ring-2 focus:ring-indigo-500 outline-none"
+                  placeholder="Add Administrator Notes (Optional)..."
+                  value={managerNotes}
+                  onChange={(e) => setManagerNotes(e.target.value)}
+                />
+              </section>
+              {higherRoleUser && (
+              <section className="bg-emerald-50 p-4 rounded-xl border border-emerald-100">
+                <h3 className="text-sm font-bold text-emerald-900 mb-3 uppercase tracking-tighter">Final Notes (Employee Viewable)</h3>
+                <textarea
+                  rows={3}
+                  className="block w-full text-sm p-3 rounded-lg border border-emerald-200 focus:ring-2 focus:ring-emerald-500 outline-none"
+                  placeholder="Add Final Notes (Optional)..."
+                  value={finalNotes}
+                  onChange={(e) => setFinalNotes(e.target.value)}
+                />
+              </section>
+              )}
             </div>
-            )
-          */}
+          )}
         </div>
 
         {/* Modal Footer */}

--- a/src/components/forms/absence-request/existing-absence.tsx
+++ b/src/components/forms/absence-request/existing-absence.tsx
@@ -10,15 +10,18 @@ import { AlertCircle, Lock } from 'lucide-react'; // Added icons for visual feed
 import { OFFICES } from '@/lib/constants';
 
 const incidentTypes = ["Late In", "Early Out", "Absent", "Leave and Come Back", "Long Lunch", "Switch Shift"];
-//const officeLocations = ["Corporate", "Ming", "Bernard", "California", "Ortho", "Delano", "Tulare", "Visalia", "Fresno"];
 
 export default function ExistingAbsenceForm({ absence, onFormSubmit, onClose }: { absence: any, onFormSubmit: () => void, onClose: () => void }) {
-
   if (!absence) return null;
   // --- 1. DEFINE DENIED STATE ---
   const isDenied = absence.manager_approval === 'denied' || absence.final_approval === 'denied';
+  const isApproved = absence.final_approval === 'approved' || absence.final_approval === 'approved_with_note';
   const isHRCallIn = absence.type_of_request === "HR Call In";
   const isPendingAction = absence.status === 'pending_action';
+
+  // Master disabled rules flags
+  const disableCoreInputs = isDenied || isApproved || isHRCallIn;
+  const disableCommentsAndFiles = isDenied;
 
   const [formData, setFormData] = useState({
     type_of_request: absence.type_of_request || '',
@@ -30,6 +33,7 @@ export default function ExistingAbsenceForm({ absence, onFormSubmit, onClose }: 
     eta: absence.eta || '',
     etd: absence.etd || '',
     excuse_note_submitted: absence.excuse_note_submitted || 'not_provided',
+    final_notes: absence.final_notes || '',
   });
 
   const [newExcuseNotes, setNewExcuseNotes] = useState<File[]>([]);
@@ -65,7 +69,9 @@ export default function ExistingAbsenceForm({ absence, onFormSubmit, onClose }: 
 const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
     if (isDenied) return; // Prevent state updates if denied
     const { name, value } = e.target;
-    // ... (rest of change logic remains same)
+
+    if (isApproved && name !== "employee_comments") return;
+
     if (name === "type_of_incident") {
       if (value === absence.type_of_incident) {
         setFormData(prev => ({ ...prev, [name]: value, eta: absence.eta || '', etd: absence.etd || '' }));
@@ -90,6 +96,7 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
   };
 
   const handleToggleRemoveExistingNote = (url: string) => {
+    if (disableCommentsAndFiles) return;
     setNotesToRemove(prev => {
       const isRemoving = !prev.includes(url);
       const nextNotesToRemove = isRemoving ? [...prev, url] : prev.filter(u => u !== url);
@@ -162,16 +169,25 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
       const remainingExistingNotes = existingNotes.filter((url: string) => !notesToRemove.includes(url));
       const finalNotes = [...remainingExistingNotes, ...newNoteUrls];
 
-      const managerApprovalStatus = isHRCallIn ? 'not_required' : 'pending';
+      // --- 4. CONDITIONAL APPROVAL STATUS UPDATE ---
+      // 💡 If already approved, do not overwrite the approvals with pending!
+      const approvalPayload = isApproved ? {
+        manager_approval: absence.manager_approval,
+        manager_approval_name: absence.manager_approval_name || '',
+        final_approval: absence.final_approval,
+        final_approval_name: absence.final_approval_name || '',
+      } : {
+        manager_approval: isHRCallIn ? 'not_required' : 'pending',
+        manager_approval_name: '',
+        final_approval: 'pending',
+        final_approval_name: '',
+      };
 
-      // --- 4. UPDATE FIRESTORE ---
+      // --- 5. UPDATE FIRESTORE ---
       await updateDoc(doc(db, "absences", absence.id), {
         ...submissionData,
         excuse_note: finalNotes,
-        manager_approval: managerApprovalStatus,
-        manager_approval_name: '',
-        final_approval: 'pending',
-        final_approval_name: '', 
+        ...approvalPayload,
         status: isPendingAction ? 'active' : (absence.status || 'active'), // 💡 Automatically activates it
         updatedAt: new Date(), 
       });
@@ -188,7 +204,6 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
   };
 
   const changed = isPendingAction ? true : isDataChanged();
-
   const activeExistingNotesCount = (absence.excuse_note || []).length - notesToRemove.length;
 
   return (
@@ -198,7 +213,7 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
           
           <div className="flex justify-between items-center mb-6">
             <h2 className="text-2xl font-bold text-gray-800">
-              {isDenied ? 'View Absence Request' : 'Edit Absence Request'}
+              {(isDenied || isApproved) ? 'View Absence Request' : 'Edit Absence Request'}
             </h2>
             {absence.status === 'archived' && (
               <h3 className="text-lg font-bold text-red-700 uppercase">Archived</h3>
@@ -213,11 +228,8 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
                 Cancel Request
               </button>
 
-              {(absence.type_of_request === "HR Call In") && (
-                <p className="text-[10px] text-slate-400 italic">Contact EXEC to cancel HR Call Ins.</p>
-              )}
-              {(absence.type_of_request !== "HR Call In" && (absence.final_approval === "approved" || absence.final_approval === "approved_with_note" || absence.final_approval === "denied" || isSubmitting)) && (
-                <p className="text-[10px] text-slate-400 italic">Contatc EXEC to cancel this request.</p>
+              {(absence.type_of_request === "HR Call In" || isApproved || absence.final_approval === "denied" || isSubmitting) && (
+                <p className="text-[10px] text-slate-400 italic text-right">Contact EXEC to cancel.</p>
               )}
               </div>
             )}
@@ -233,13 +245,27 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
               </div>
             </div>
           )}
+
+          {isApproved && (
+            <div className="mb-6 p-4 bg-emerald-50 border border-emerald-200 rounded-xl flex items-center gap-3">
+              <Lock className="h-5 w-5 text-emerald-500" />
+              <div>
+                <p className="text-sm font-bold text-emerald-800">Request Approved</p>
+                <p className="text-xs text-emerald-600">The request is locked. You may still write notes or append additional files.</p>
+              </div>
+            </div>
+          )}
           
           <form onSubmit={handleSubmit} className="space-y-5">
             {/* Request Type */}
             <div className="p-4 bg-amber-50 rounded-lg border border-amber-200">
               <label className="block text-sm font-semibold text-amber-900 mb-2">Type Of Request</label>
-              <div className="flex gap-6 text-sm">
-                {["Incident Notice", "Time Off Request", "HR Call In"].map(val => (
+              <div className="flex flex-wrap gap-6 text-sm">
+                {["Incident Notice", "Time Off Request", "HR Call In", "No Call", "Call In After Shift", "Previously Not Approved"].map(val => {
+                  const specialTypes = ["HR Call In", "No Call", "Call In After Shift", "Previously Not Approved"]
+                  const isSpecialType = specialTypes.includes(absence.type_of_request);
+                  const isRadioDisabled = disableCoreInputs || isSpecialType || (specialTypes.includes(val) && !specialTypes.includes(formData.type_of_request));
+                  return (
                   <label key={val} className="flex items-center gap-2 cursor-pointer">
                     <input 
                       type="radio" 
@@ -247,12 +273,13 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
                       value={val} 
                       checked={formData.type_of_request === val} 
                       onChange={handleChange} 
-                      disabled={isDenied || isHRCallIn || (val === "HR Call In" && formData.type_of_request !== "HR Call In")} // Disable
+                      disabled={isRadioDisabled} // Disable
                       className="accent-amber-600 disabled:opacity-50" 
                     />
-                    <span className={`text-amber-800 ${(isDenied || isHRCallIn || (val === "HR Call In" && formData.type_of_request !== "HR Call In")) ? 'opacity-40' : ''}`}>{val}</span>
+                    <span className={`text-amber-800 ${(isRadioDisabled) ? 'opacity-40' : ''}`}>{val}</span>
                   </label>
-                ))}
+                );
+                })}
               </div>
             </div>
 
@@ -260,13 +287,13 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-1">
                 <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">Incident Type</label>
-                <select name="type_of_incident" value={formData.type_of_incident} onChange={handleChange} disabled={isDenied || isHRCallIn} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50 disabled:text-gray-500" required>
+                <select name="type_of_incident" value={formData.type_of_incident} onChange={handleChange} disabled={disableCoreInputs} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50 disabled:text-gray-500" required>
                   {incidentTypes.map(t => <option key={t} value={t}>{t}</option>)}
                 </select>
               </div>
               <div className="space-y-1">
                 <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">Office Location</label>
-                <select name="office" value={formData.office} onChange={handleChange} disabled={isDenied || isHRCallIn} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50 disabled:text-gray-500" required>
+                <select name="office" value={formData.office} onChange={handleChange} disabled={disableCoreInputs} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50 disabled:text-gray-500" required>
                   {OFFICES.map(o => <option key={o} value={o}>{o}</option>)}
                 </select>
               </div>
@@ -276,11 +303,11 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-1">
                 <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">Start Date</label>
-                <input name="incident_start" type="date" value={formData.incident_start} onChange={handleChange} disabled={isDenied || isHRCallIn} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50" required />
+                <input name="incident_start" type="date" value={formData.incident_start} onChange={handleChange} disabled={disableCoreInputs} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50" required />
               </div>
               <div className="space-y-1">
                 <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">End Date</label>
-                <input name="incident_end" type="date" value={formData.incident_end} onChange={handleChange} disabled={isDenied || isHRCallIn} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50" required />
+                <input name="incident_end" type="date" value={formData.incident_end} onChange={handleChange} disabled={disableCoreInputs} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50" required />
               </div>
             </div>
 
@@ -289,13 +316,13 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
               {["Late In", "Leave and Come Back"].includes(formData.type_of_incident) && (
                 <div className="space-y-1">
                   <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">ETA (Arrival)</label>
-                  <input name="eta" type="time" value={formData.eta} onChange={handleChange} disabled={isDenied || isHRCallIn} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50" required />
+                  <input name="eta" type="time" value={formData.eta} onChange={handleChange} disabled={disableCoreInputs} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50" required />
                 </div>
               )}
               {["Early Out", "Leave and Come Back"].includes(formData.type_of_incident) && (
                 <div className="space-y-1">
                   <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">ETD (Departure)</label>
-                  <input name="etd" type="time" value={formData.etd} onChange={handleChange} disabled={isDenied || isHRCallIn} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50" required />
+                  <input name="etd" type="time" value={formData.etd} onChange={handleChange} disabled={disableCoreInputs} className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50" required />
                 </div>
               )}
             </div>
@@ -310,7 +337,7 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
                 name="employee_comments" 
                 value={formData.employee_comments} 
                 onChange={handleChange} 
-                disabled={isDenied} 
+                disabled={disableCommentsAndFiles} 
                 required={isPendingAction} // 💡 Dynamically requires input
                 placeholder={'Notes and Comments...'}
                 className="w-full border border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50 focus:ring-1 focus:ring-blue-500" 
@@ -319,8 +346,8 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
             </div>
 
           {/* File Management Container */}
-          <div className={`p-4 rounded-lg space-y-3 mt-1 ${isDenied ? 'bg-slate-50 border border-slate-200' : 'bg-blue-50 border border-blue-200'}`}>
-            <p className={`text-xs font-bold uppercase ${isDenied ? 'text-slate-500' : 'text-blue-800'}`}>Notes & Files</p>
+          <div className={`p-4 rounded-lg space-y-3 mt-1 ${disableCommentsAndFiles ? 'bg-slate-50 border border-slate-200' : 'bg-blue-50 border border-blue-200'}`}>
+            <p className={`text-xs font-bold uppercase ${disableCommentsAndFiles ? 'text-slate-500' : 'text-blue-800'}`}>Notes & Files</p>
 
             {/* 1. Existing Uploaded Files Array */}
             {absence.excuse_note?.map((url: string, i: number) => {
@@ -338,7 +365,7 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
                   >
                     {fileName}
                   </a>
-                  {!isDenied && (
+                  {!disableCommentsAndFiles && (
                     <button type="button" onClick={() => handleToggleRemoveExistingNote(url)} className={`text-[10px] font-bold uppercase ml-2 px-2 py-1 rounded ${isMarkedForDeletion ? 'text-green-600 hover:bg-green-50' : 'text-red-500 hover:bg-red-50'}`}>
                       {isMarkedForDeletion ? 'Undo Delete' : 'Remove'}
                     </button>
@@ -347,7 +374,7 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
               );
             })}
 
-            {/* 2. Brand New Staged Files Preview List (Crucial Missing Feature!) */}
+            {/* 2. Brand New Staged Files Preview List*/}
             {newExcuseNotes.length > 0 && (
               <div className="space-y-1.5 pt-1 border-t border-blue-100/50">
                 <p className="text-[10px] font-bold text-blue-500 uppercase tracking-wider">Staged for Upload:</p>
@@ -380,7 +407,7 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
             )}
 
             {/* 3. Standard File Selector Input Trigger */}
-            {!isDenied && (    
+            {!disableCommentsAndFiles && (    
               <div className="flex items-center gap-3 mt-2">
                 <label 
                   htmlFor="file-upload" 
@@ -434,6 +461,17 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
             )}
           </div>
 
+          {formData.final_notes && (
+            <div className="space-y-1">
+              <label className="text-xs font-bold text-rose-700 uppercase tracking-wider">
+                Final Notes
+              </label>
+              <p className="w-full border font-semibold bg-slate-50 border-gray-300 p-2.5 rounded-md outline-none disabled:bg-gray-50 focus:ring-1 focus:ring-blue-500">
+                {formData.final_notes} 
+              </p>
+            </div>
+          )}
+
             {/* Checkbox text modification */}
             {changed && !isDenied && (
               <div className="flex items-start gap-2 px-1 pt-2 animate-in fade-in slide-in-from-top-1 duration-300">
@@ -447,6 +485,8 @@ const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement 
                 <label htmlFor="confirm-update" className="text-xs text-gray-600 leading-tight cursor-pointer">
                   {isPendingAction ? (
                     <span>I have read and acknowledge this absence record.</span>
+                  ) : isApproved ? (
+                    <span>I confirm these supplemental notes/files are accurate. <span className="font-bold text-gray-800">Note: This will preserve your current approval status.</span></span>
                   ) : (
                     <span>I confirm these updates are accurate. <span className="font-bold text-gray-800">Note: This will reset the approval status to pending.</span></span>
                   )}

--- a/src/components/forms/absence-request/hr-absence.tsx
+++ b/src/components/forms/absence-request/hr-absence.tsx
@@ -41,6 +41,8 @@ const initialState = {
   manager_notes: '',
   DOAPoints: 0,
   pendingDOAPoints: 0,
+  final_notes: '',
+  DAP: 0,
   status: 'active',
 };
 
@@ -126,8 +128,10 @@ export const HRCreateAbsenceModal = ({ isOpen, onClose, onSave }: HRCreateAbsenc
 
     setIsSubmitting(true);
     try {
+      const isSpecialCallIn = ["HR Call In", "No Call", "Call In After Shift"].includes(formData.type_of_request);
+
       let finalManagerApproval = formData.manager_approval;
-      if (formData.type_of_request === "HR Call In") {
+      if (isSpecialCallIn) {
         finalManagerApproval = "not_required";
       } 
       else {
@@ -136,7 +140,7 @@ export const HRCreateAbsenceModal = ({ isOpen, onClose, onSave }: HRCreateAbsenc
         finalManagerApproval = selectedEmployee?.skipManagerApproval ? "not_required" : "pending";
       }
 
-      const finalStatus = formData.type_of_request === "HR Call In" ? "pending_action" : "active";
+      const finalStatus = isSpecialCallIn ? "pending_action" : "active";
 
       await addDoc(collection(db, "absences"), {
         ...formData,
@@ -244,8 +248,8 @@ export const HRCreateAbsenceModal = ({ isOpen, onClose, onSave }: HRCreateAbsenc
                 <div className="grid grid-cols-1 gap-4">
                   <div className="space-y-1">
                     <label className="text-[10px] font-black text-slate-400 uppercase ml-1">Type of Request</label>
-                    <div className="w-full p-4 bg-slate-50 rounded-xl border-none flex gap-4 text-xs font-bold">
-                    {["HR Call In", "Incident Notice", "Time Off Request"].map((type) => (
+                    <div className="w-full p-4 bg-slate-50 rounded-xl border-none grid grid-cols-3 gap-4 text-xs font-bold">
+                    {["HR Call In", "Incident Notice", "Time Off Request", "No Call", "Call In After Shift"].map((type) => (
                       <label key={type} className="flex items-center gap-1.5 cursor-pointer select-none">
                         <input 
                         type="radio" 

--- a/src/components/forms/absence-request/new-absence.tsx
+++ b/src/components/forms/absence-request/new-absence.tsx
@@ -43,6 +43,8 @@ export default function NewAbsenceForm({employeeFirestore, employeeID, employeeT
     manager_approval_name: '',
     final_approval: 'pending',
     final_approval_name: '', 
+    final_notes: '',
+    DAP: 0,
     skipManagerApproval: employeeSkipManagerApproval || false,
     DOAPoints: 0,
     status: 'active',

--- a/src/components/forms/absence-request/volunteer-early-out.tsx
+++ b/src/components/forms/absence-request/volunteer-early-out.tsx
@@ -218,6 +218,7 @@ export const EarlyOutForm = ({ onClose }: EarlyOutFormProps) => {
                 <div className="flex gap-2">
                   <input 
                     autoFocus
+                    type="password"
                     placeholder="Employee ID #"
                     className="flex-1 p-4 bg-slate-100 rounded-2xl border-2 border-transparent focus:border-indigo-500 focus:bg-white outline-none font-bold text-center text-xl transition-all"
                     value={tempID}
@@ -324,6 +325,7 @@ export const EarlyOutForm = ({ onClose }: EarlyOutFormProps) => {
                           placeholder="Supervisor Employee ID #"
                           className="flex-1 p-3 bg-white rounded-xl border border-slate-200 focus:border-indigo-500 outline-none font-bold text-sm transition-all"
                           value={supervisorID}
+                          type="password"
                           disabled={Boolean(supervisorEmployeeName)}
                           onChange={(e) => setSupervisorID(e.target.value)}
                           onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), handleLookupSupervisor())}

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -46,14 +46,20 @@ export function LoginForm({
 
   // Function to handle google sign in
   const handleGoogleSignIn = async () => {
+    try {
     const provider = new GoogleAuthProvider();
     provider.setCustomParameters({
       prompt: 'select_account' // Ensures the user selects an account
     })
-    try {
       await signInWithPopup(auth, provider); 
-    } catch (error) {
-      console.error('Error during Google sign-in:', error); 
+    } catch (error: any) {
+      if (error.code === "auth/cancelled-popup-request" || error.code === "auth/popup-closed-by-user") {
+        console.log("User closed or canceled the sign-in popup.");
+        // Soft exit—don't alert the user, they know they closed it!
+        return; 
+      }
+      // Handle real authentication errors normally
+      console.error("Sign-in error:", error);
     }
   };
 

--- a/src/components/ui/status-badge.tsx
+++ b/src/components/ui/status-badge.tsx
@@ -8,12 +8,13 @@ const styles: Record<string, string> = {
   green: 'bg-emerald-100 text-emerald-700 ring-emerald-600/20',
   red: 'bg-rose-100 text-rose-700 ring-rose-600/20',
   yellow: 'bg-amber-100 text-amber-700 ring-amber-600/20',
-  gray: 'bg-slate-100 text-slate-600 ring-slate-600/10',
+  gray: 'bg-slate-100 text-slate-600 ring-slate-600/20',
+  blue: 'bg-cyan-100 text-cyan-600 ring-cyan-600/20' 
 };
 
 export const Badge = ({ color, text }: { color: string; text: string }) => {
   return (
-    <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-black text-[10px] uppercase ring-1 ring-inset ${styles[color]}`}>
+    <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-black text-[10px] uppercase ring-1 ring-inset shadow-sm ${styles[color]}`}>
       {text}
     </span>
   );
@@ -21,7 +22,7 @@ export const Badge = ({ color, text }: { color: string; text: string }) => {
 
 export const StatusBadge = ({ req }: { req: AbsenceRequest }) => {
   const statusText = getRequestStatusText(req);
-  
+  if (statusText === "Pending Employee") return <Badge color="blue" text={statusText} />;
   if (statusText === "Manager Denied" || statusText === "Denied") return <Badge color="red" text={statusText} />;
   if (statusText === "Approved" || statusText === "Approved With Note") return <Badge color="green" text={statusText} />;
   if (statusText === "Manager Approved" || statusText === "Pending Final Approval") return <Badge color="yellow" text={statusText} />;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,11 +21,13 @@ export type AbsenceRequest = {
   manager_notes?: string;
   office: string; // Office location associated with the employee making request
   type_of_incident: string; // "Late In", "Early Out", "Absent", "Leave and Come Back", "Long Lunch", "Switch Shift"
-  type_of_request: string; // Either "Time Off Request" or "Incident Notice" for the User // "HR Call In" for HR created requests
+  type_of_request: string; // Either "Time Off Request" or "Incident Notice" for the User // "HR Call In" for HR created requests // "No Call", "Call In After Shift", "Previously Not Approved"
   updatedAt?: Timestamp;
   skipManagerApproval: boolean; // Field to indicate if manager approval is skipped (true/false)
   DOAPoints: number; // Points assigned for the DOA system based on the hours missed
   pendingDOAPoints: number; // Points that are pending and will be added to DOAPoints if the request is approved
+  DAP: number;
+  final_notes?: string;
   status: 'active' | 'archived' | 'pending_action'; // New field to indicate if the request is active or archived, including a way to check if it is an initial 'HR Call In' Request
 };
 


### PR DESCRIPTION
- Added Pending Employee Status with different color status badge.
- Employees can add notes and comments without resetting the absence request approval process.
- Added 3 Different types_of_request: No Call, Call In After Shift, Previously Not Approved
- Managers can see Pending Employee Tab
- Added DAP and DAP Column to HR Table, but removed edit button. Selected Request Modal can be opened by clicking the name of the employee now.
- Added another comment section to the absence requests. These comments are only by the exec department and can be viewable by the employee after approval or denial of their absence request.
- Hide login information, id and birth year, is employee absence page and early out form.
- Updated main login form to prevent error regarding cancelling a login.