### PR TITLE
Fixed Volunteer-Early-Outs Bug

### DIFF
--- a/src/app/dashboard/tools/volunteer-early-outs/page.tsx
+++ b/src/app/dashboard/tools/volunteer-early-outs/page.tsx
@@ -32,12 +32,12 @@ export default function Page() {
   const [startDate, setStartDate] = useState(() => {
     const d = new Date();
     d.setDate(d.getDate()-1);
-    return d.toISOString().split("T")[0];
+    return d.toLocaleDateString('en-CA');
   });
   const [endDate, setEndDate] = useState(() => {
     const d = new Date();
     d.setDate(d.getDate()+1);
-    return d.toISOString().split("T")[0];
+    return d.toLocaleDateString('en-CA');
   });
 
   const [submissions, setSubmissions] = useState<VolunteerEarlyOutRequest[]>([]);


### PR DESCRIPTION
The old string was a UTC string that was assigned to the next day instead of the current day in PST. We hard coded the date string to match California's date.